### PR TITLE
Fix: Update Ubuntu version from 20.04 (Focal) to 22.04 (Jammy)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -136,9 +136,9 @@ resource "azurerm_linux_virtual_machine" "ten_validatorApp_terraform_vm" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-focal"
-    sku       = "20_04-lts-gen2"
-    version   = "20.04.202206220"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
   }
 
   computer_name  = "tenvalidatorVM"


### PR DESCRIPTION
## Problem
The Docker installation script was showing a deprecation warning because Ubuntu Focal (20.04) has reached end-of-life and is no longer supported:

```
DEPRECATION WARNING
This Linux distribution (ubuntu focal) reached end-of-life and is no longer supported by this script.
No updates or security fixes will be released for this distribution, and users are recommended
to upgrade to a currently maintained version of ubuntu.
```

## Solution
Updated the Terraform configuration to use Ubuntu 22.04 LTS (Jammy) instead of Ubuntu 20.04 (Focal):

- Changed `offer` from `0001-com-ubuntu-server-focal` to `0001-com-ubuntu-server-jammy`
- Changed `sku` from `20_04-lts-gen2` to `22_04-lts-gen2`
- Updated `version` to `latest` to get the most recent security patches

## Benefits
- ✅ Resolves Docker installation deprecation warning
- ✅ Ensures continued security updates and support
- ✅ Uses a currently maintained Ubuntu LTS version
- ✅ Maintains compatibility with existing Go and other dependencies

## Testing
- [x] Terraform configuration validates successfully
- [x] Go 1.21.13 is compatible with Ubuntu 22.04
- [x] No breaking changes to existing functionality

## Files Changed
- `terraform/main.tf`: Updated VM image reference to Ubuntu 22.04